### PR TITLE
Trim permission tokens (ng-if-permission) #11

### DIFF
--- a/src/directives.js
+++ b/src/directives.js
@@ -89,7 +89,7 @@ function ifPermission ($security) {
   function link (scope, element, attrs) {
     var defaultStyle = element.css('display'),
         permissionType = attrs.ngPermissionType,
-        permissions = attrs.ngIfPermission.split(',');
+        permissions = attrs.ngIfPermission.split(/[\s,]+/);
 
     scope.$watch(function () {
       return $security.getPermissions();
@@ -152,7 +152,7 @@ function enabledPermission ($security) {
   /** implementation */
   function link (scope, element, attrs) {
     var permissionType = attrs.ngPermissionType,
-        permissions = attrs.ngEnabledPermission.split(',');
+        permissions = attrs.ngEnabledPermission.split(/[\s,]+/);
 
     scope.$watch(function () {
       return $security.getPermissions();


### PR DESCRIPTION
A comma separated string could be writted with white spaces, at least in my case:
ng-if-permission="ROLE_ADMINISTRADOR, ROLE_SUPERVISOR"

It is solved and made the code more robust using trim and split as:
permissions = attrs.ngIfPermission.split(/[\s,]+/);